### PR TITLE
add dependabot coverage for githubactions and nuget

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "nuget"
+    directory: “/”
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
The goal of this PR is to add a basic dependabot config which will open PR to upgrade Nuget packages and GitHub actions present in repo's workflows

https://github.com/G-Research/oss-portfolio-maturity/issues/346