### PR TITLE
Enable GitHub release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,7 @@ jobs:
   # Publish NuGet packages when a tag is pushed.
   # Build needs to succeed first, including having a tag name that matches the version number.
   publish-release:
-    # if: ${{ !github.event.repository.fork && startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ !github.event.repository.fork && startsWith(github.ref, 'refs/tags/v') }}
     needs: Bulldog
     runs-on: windows-latest
     steps:


### PR DESCRIPTION
The goal of this PR is to enable publish of the GitHub release 

Example workflow: https://github.com/ljubon/Bulldog/actions/runs/7760574148/job/21167216094

Example release: https://github.com/ljubon/Bulldog/releases